### PR TITLE
Brought in Docker build scripts into an alltrails folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ local.properties
 .DS_Store
 /graph-cache
 package-lock.json
+
+# AllTrails specific
+alltrails/data/*
+!alltrails/data/.gitkeep

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ https://github.com/alltrails/graphhopper/compare/master...alltrails:graphhopper:
 
 Then proceed as normal.  This is a GitHub feature that cannot be changed.
 
-Below is the GraphHopper README as at the start of the fork
+Remainder of this README is the GraphHopper README as at the start of the fork.
+
+See alltrails/README.md for how to build, test and deploy our forked GraphHopper.
 
 ---
 

--- a/alltrails/.dockerignore
+++ b/alltrails/.dockerignore
@@ -1,0 +1,6 @@
+# Block everything by default
+*
+
+# Allow just the things we need to run the app
+!graphhopper
+!config

--- a/alltrails/Dockerfile
+++ b/alltrails/Dockerfile
@@ -1,0 +1,24 @@
+FROM maven:3.9.5-eclipse-temurin-21 as build
+
+WORKDIR /graphhopper
+
+COPY . .
+
+RUN mvn clean install -DskipTests
+
+
+FROM eclipse-temurin:21.0.1_12-jre
+
+ENV JAVA_OPTS "-Xmx2g -Xms2g"
+
+WORKDIR /graphhopper
+
+COPY --from=build /graphhopper/web/target/graphhopper*.jar ./
+
+COPY alltrails/config/graphhopper.sh alltrails/config/config-alltrails.yml ./
+
+EXPOSE 8989 8990
+
+HEALTHCHECK --interval=5s --timeout=3s CMD curl --fail http://localhost:8989/health || exit 1
+
+ENTRYPOINT [ "./graphhopper.sh", "-c", "config-alltrails.yml", "-o", "/graphhopper/data/default-gh" ]

--- a/alltrails/README.md
+++ b/alltrails/README.md
@@ -1,0 +1,94 @@
+# graphhopper-service
+
+AllTrails custom GraphHopper routing service using israelhikingmap/graphhopper Docker as a base. This service was created to support the BYOT project.
+
+## Repository files
+
+- `helm/graphhopper-service` : Helm chart for this service
+- `scripts` : scripts for building local and Linux Docker images
+- `config` : GraphHopper config files to copy into image at build-time
+- `graphhopper` : GraphHopper service.  Fork of Java GraphHopper repo, with AT-specific code changes
+- `data` : Mount point for local dev: download OSM PBF files to this, and to build GraphHopper's routing network files to
+
+## Local development
+
+### Building and Running GraphHopper Java App (outside of Docker)
+
+It is useful when making changes to the Java code to be able to build and run it outside a container.
+The `mvn` build step is slow - I am sure there is a much more efficient waty to run it incrementally during development.
+```Bash
+# Build Java app
+cd .. # If needed, to root of `graphhopper` repo
+mvn clean install -DskipTest
+# Run it in "import" mode to import an OSM PBF file and an AT CSV custom attribute file
+# Data files should be in `alltrails/data` 
+rm -r alltrails/data/default-gh
+java -Ddw.graphhopper.datareader.file=alltrails/data/california-latest.osm.pbf \
+  -Ddw.graphhopper.graph.location=alltrails/data/default-gh \
+  -jar web/target/graphhopper-web-*.jar import alltrails/config/config-alltrails.yml
+# Run it as local server, http://localhost:8989/maps/
+java -Ddw.graphhopper.graph.location=alltrails/data/default-gh \
+  -jar web/target/graphhopper-web-*.jar server alltrails/config/config-alltrails.yml
+
+```
+
+### Building and Running Docker Image
+
+1. Build Docker image:
+
+```Bash
+cd .. # If needed, to root of `graphhopper` repo
+alltrails/scripts/build_graphhopper.sh
+```
+
+2. Run Docker container locally to import data
+
+**Note** Without further Java tuning within the container this import will only work with small OSM PBF files.
+Use the raw Java app above to build larger ones.
+This method also does not currently support the `datareader.at_csv` import
+
+```Bash
+rm -r alltrails/data/default-gh
+docker run --rm -p 8989:8989 -v ./alltrails/data:/graphhopper/data graphhopper-service --import -i /graphhopper/data/california-latest.osm.pbf
+```
+
+3. Run Docker container locally as a server, http://localhost:8989/maps/
+
+```Bash
+docker run --rm -p 8989:8989 -v ./alltrails/data:/graphhopper/data graphhopper-service --host 0.0.0.0
+```
+
+4. Build and push Linux image to ECR:
+
+```Bash
+# Login if needed (this example is for Mostpaths)
+aws eks --region us-west-2 update-kubeconfig --name eks-alpha
+kubectl config set-context --current --namespace=alpha # no need to then add -n alpha 
+docker login -u AWS -p $(aws ecr get-login-password --region us-west-2) 873326996015.dkr.ecr.us-west-2.amazonaws.com
+
+# Build/push
+alltrails/scripts/build_linux_graphhopper.sh
+# See below for restarting service with new image
+```
+
+5. Updating the Alpha service's data
+
+Upload all 10 files from local data/default-gh folder to default-gh folder in S3 bucket https://us-west-2.console.aws.amazon.com/s3/buckets/alltrails-alpha-us-west-2-graphhopper-service?region=us-west-2&bucketType=general&prefix=default-gh/&showversions=false
+
+Then restart containers with new data (or use this after image change in ECR)
+
+```Bash
+kubectl rollout restart deploy graphhopper-service-tester
+kubectl get pods | grep graphhopper
+```
+
+## Interactive map service URLs
+http://localhost:8989/maps/?profile=hike&layer=OpenStreetMap
+
+https://alpha.mostpaths.com/api/alltrails/graphhopper-service/maps/?profile=hike&layer=OpenStreetMap
+
+## Example routing call (can be GET or POST)
+http://localhost:8989/route?point=40.3517,-106.3860&point=40.2831,-106.3466&profile=hike
+
+## Routing service info
+https://alpha.mostpaths.com/api/alltrails/graphhopper-service/info

--- a/alltrails/config/config-alltrails.yml
+++ b/alltrails/config/config-alltrails.yml
@@ -1,0 +1,254 @@
+graphhopper:
+
+  # OpenStreetMap input file PBF or XML, can be changed via command line -Ddw.graphhopper.datareader.file=some.pbf
+  datareader.file: ""
+  # Local folder used by graphhopper to store its data
+  graph.location: graph-cache
+  # Lock type
+  # graph.locktype: simple
+
+
+  ##### Routing Profiles ####
+
+  # Routing can be done only for profiles listed below. For more information about profiles and custom profiles have a
+  # look into the documentation at docs/core/profiles.md or the examples under web/src/test/java/com/graphhopper/application/resources/
+  # or the CustomWeighting class for the raw details.
+  #
+  # In general a profile consists of the following
+  # - name (required): a unique string identifier for the profile
+  # - weighting (optional): by default 'custom'
+  # - turn_costs (optional):
+  #     vehicle_types: [motorcar, motor_vehicle] (vehicle types used for vehicle-specific turn restrictions)
+  #     u_turn_costs: 60 (time-penalty for doing a u-turn in seconds)
+  #
+  # Depending on the above fields there are other properties that can be used, e.g.
+  # - custom_model_files: when you specified "weighting: custom" you need to set one or more json files which are searched in
+  #   custom_models.directory or the working directory that defines the custom_model. If you want an empty model you can
+  #   set "custom_model_files: []
+  #   You can also use the `custom_model` field instead and specify your custom model in the profile directly.
+  #
+  # To prevent long running routing queries you should usually enable either speed or hybrid mode for all the given
+  # profiles (see below). Or at least limit the number of `routing.max_visited_nodes`.
+
+  profiles:
+#   - name: car
+#     turn_costs:
+#       vehicle_types: [motorcar, motor_vehicle]
+#       u_turn_costs: 60
+#      custom_model_files: [car.json]
+
+#   - name: foot
+#     custom_model_files: [foot.json, foot_elevation.json]
+    - name: hike
+      custom_model_files: [hike.json]
+
+#    - name: bike
+#      custom_model_files: [bike.json, bike_elevation.json]
+#
+#    - name: racingbike
+#      custom_model_files: [racingbike.json, bike_elevation.json]
+#
+#    - name: mtb
+#      custom_model_files: [mtb.json, bike_elevation.json]
+
+  # instead of the inbuilt custom models (see ./core/src/main/resources/com/graphhopper/custom_models)
+  # you can specify a folder where to find your own custom model files
+  # custom_models.directory: custom_models
+
+  # Speed mode:
+  # It's possible to speed up routing by doing a special graph preparation (Contraction Hierarchies, CH). This requires
+  # more RAM/disk space for holding the prepared graph but also means less memory usage per request. Using the following
+  # list you can define for which of the above routing profiles such preparation shall be performed. Note that to support
+  # profiles with `turn_costs: true` a more elaborate preparation is required (longer preparation time and more memory
+  # usage) and the routing will also be slower than with `turn_costs: false`.
+  profiles_ch:
+  #   - profile: car
+    - profile: hike
+
+  # Hybrid mode:
+  # Similar to speed mode, the hybrid mode (Landmarks, LM) also speeds up routing by doing calculating auxiliary data
+  # in advance. Its not as fast as speed mode, but more flexible.
+  #
+  # Advanced usage: It is possible to use the same preparation for multiple profiles which saves memory and preparation
+  # time. To do this use e.g. `preparation_profile: my_other_profile` where `my_other_profile` is the name of another
+  # profile for which an LM profile exists. Important: This only will give correct routing results if the weights
+  # calculated for the profile are equal or larger (for every edge) than those calculated for the profile that was used
+  # for the preparation (`my_other_profile`)
+  profiles_lm: []
+
+
+  #### Encoded Values ####
+
+  # Add additional information to every edge. Used for path details (#1548) and custom models (docs/core/custom-models.md)
+  # Default values are: road_class,road_class_link,road_environment,max_speed,road_access
+  # More are: surface,smoothness,max_width,max_height,max_weight,max_weight_except,hgv,max_axle_load,max_length,
+  #           hazmat,hazmat_tunnel,hazmat_water,lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating,
+  #           country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,foot_temporal_access
+  # graph.encoded_values: car_access, car_average_speed
+  graph.encoded_values: surface, smoothness, track_type, hike_rating, average_slope, foot_access, foot_network, foot_priority, foot_average_speed, mtb_rating, at_popularity, at_scenic_value, foot_road_access
+
+  #### Speed, hybrid and flexible mode ####
+
+  # To make CH preparation faster for multiple profiles you can increase the default threads if you have enough RAM.
+  # Change this setting only if you know what you are doing and if the default worked for you.
+  # prepare.ch.threads: 1
+
+  # To tune the performance vs. memory usage for the hybrid mode use
+  # prepare.lm.landmarks: 16
+
+  # Make landmark preparation parallel if you have enough RAM. Change this only if you know what you are doing and if
+  # the default worked for you.
+  # prepare.lm.threads: 1
+
+
+  #### Elevation ####
+
+  # To populate your graph with elevation data use SRTM, default is noop (no elevation). Read more about it in docs/core/elevation.md
+  graph.elevation.provider: srtm
+
+  # default location for cache is /tmp/srtm
+  # graph.elevation.cache_dir: ./srtmprovider/
+
+  # If you have a slow disk or plenty of RAM change the default MMAP to:
+  # graph.elevation.dataaccess: RAM_STORE
+
+  # To enable bilinear interpolation when sampling elevation at points (default uses nearest neighbor):
+  graph.elevation.interpolate: bilinear
+
+  # Reduce ascend/descend per edge without changing the maximum slope:
+  # graph.elevation.edge_smoothing: ramer
+  # removes elevation fluctuations up to max_elevation (in meter) and replaces the elevation with a value based on the average slope
+  # graph.elevation.edge_smoothing.ramer.max_elevation: 5
+  # Using an averaging approach for smoothing will reveal values not affected by outliers and realistic slopes and total altitude values (up and down)
+  # graph.elevation.edge_smoothing: moving_average
+  # window size in meter along a way used for averaging a node's elevation
+  # graph.elevation.edge_smoothing.moving_average.window_size: 150
+
+
+  # To increase elevation profile resolution, use the following two parameters to tune the extra resolution you need
+  # against the additional storage space used for edge geometries. You should enable bilinear interpolation when using
+  # these features (see #1953 for details).
+  # - first, set the distance (in meters) at which elevation samples should be taken on long edges
+  # graph.elevation.long_edge_sampling_distance: 60
+  # - second, set the elevation tolerance (in meters) to use when simplifying polylines since the default ignores
+  #   elevation and will remove the extra points that long edge sampling added
+  # graph.elevation.way_point_max_distance: 10
+
+
+  #### Country-dependent defaults for max speeds ####
+
+  # This features sets a maximum speed in 'max_speed' encoded value if no maxspeed tag was found. It is country-dependent
+  # and based on several rules. See https://github.com/westnordost/osm-legal-default-speeds
+  # To use it uncomment the following, then enable urban density below and add 'country' to graph.encoded_values
+  # max_speed_calculator.enabled: true
+
+
+  #### Urban density (built-up areas) ####
+
+  # This feature allows classifying roads into 'rural', 'residential' and 'city' areas (encoded value 'urban_density')
+  # Use 1 or more threads to enable the feature
+  # graph.urban_density.threads: 8
+  # Use higher/lower sensitivities if too little/many roads fall into the according categories.
+  # Using smaller radii will speed up the classification, but only change these values if you know what you are doing.
+  # If you do not need the (rather slow) city classification set city_radius to zero.
+  # graph.urban_density.residential_radius: 400
+  # graph.urban_density.residential_sensitivity: 6000
+  # graph.urban_density.city_radius: 1500
+  # graph.urban_density.city_sensitivity: 1000
+
+
+  #### Subnetworks ####
+
+  # In many cases the road network consists of independent components without any routes going in between. In
+  # the most simple case you can imagine an island without a bridge or ferry connection. The following parameter
+  # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
+  # of cases where a connection between locations might not be found.
+  prepare.min_network_size: 200
+  prepare.subnetworks.threads: 1
+
+  #### Routing ####
+
+  # You can define the maximum visited nodes when routing. This may result in not found connections if there is no
+  # connection between two points within the given visited nodes. The default is Integer.MAX_VALUE. Useful for flexibility mode
+  # routing.max_visited_nodes: 1000000
+
+  # The maximum time in milliseconds after which a routing request will be aborted. This has some routing algorithm
+  # specific caveats, but generally it should allow the prevention of long-running requests. The default is Long.MAX_VALUE
+  # routing.timeout_ms: 300000
+
+  # Control how many active landmarks are picked per default, this can improve query performance
+  # routing.lm.active_landmarks: 4
+
+  # You can limit the max distance between two consecutive waypoints of flexible routing requests to be less or equal
+  # the given distance in meter. Default is set to 1000km.
+  routing.non_ch.max_waypoint_distance: 1000000
+
+
+  #### Storage ####
+
+  # Excludes certain types of highways during the OSM import to speed up the process and reduce the size of the graph.
+  # A typical application is excluding 'footway','cycleway','path' and maybe 'pedestrian' and 'track' highways for
+  # motorized vehicles. This leads to a smaller and less dense graph, because there are fewer ways (obviously),
+  # but also because there are fewer crossings between highways (=junctions).
+  # Another typical example is excluding 'motorway', 'trunk' and maybe 'primary' highways for bicycle or pedestrian routing.
+  # import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps # typically useful for motorized-only routing
+  import.osm.ignored_highways: motorway,trunk # typically useful for non-motorized routing
+
+  # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
+  graph.dataaccess.default_type: RAM_STORE
+
+  # will write way names in the preferred language (language code as defined in ISO 639-1 or ISO 639-2):
+  # datareader.preferred_language: en
+
+  #### Custom Areas ####
+
+  # GraphHopper reads GeoJSON polygon files including their properties from this directory and makes them available
+  # to all tag parsers and custom models. All GeoJSON Features require to have the "id" property.
+  # Country borders are included automatically (see countries.geojson).
+  # custom_areas.directory: path/to/custom_areas
+
+
+  #### Country Rules ####
+
+  # GraphHopper applies country-specific routing rules during import (not enabled by default).
+  # You need to redo the import for changes to take effect.
+  # country_rules.enabled: true
+
+# Dropwizard server configuration
+server:
+  application_connectors:
+  - type: http
+    port: 8989
+    # for security reasons bind to localhost
+    # bind_host: localhost
+    # increase GET request limit - not necessary if /maps UI is not used or used without custom models
+    max_request_header_size: 50k
+  request_log:
+      appenders: []
+  admin_connectors:
+  - type: http
+    port: 8990
+    bind_host: localhost
+# See https://www.dropwizard.io/en/latest/manual/core.html#logging
+logging:
+  appenders:
+    - type: file
+      time_zone: UTC
+      current_log_filename: logs/graphhopper.log
+      log_format: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+      archive: true
+      archived_log_filename_pattern: ./logs/graphhopper-%d.log.gz
+      archived_file_count: 30
+      never_block: true
+    - type: console
+      time_zone: UTC
+      log_format: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+  loggers:
+    "com.graphhopper.osm_warnings":
+      level: DEBUG
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: logs/osm_warnings.log
+          archive: false
+          logFormat: '[%level] %msg%n'

--- a/alltrails/config/graphhopper.sh
+++ b/alltrails/config/graphhopper.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+(set -o igncr) 2>/dev/null && set -o igncr; # this comment is required for handling Windows cr/lf
+# See StackOverflow answer http://stackoverflow.com/a/14607651
+
+GH_HOME=$(dirname "$0")
+JAVA=$JAVA_HOME/bin/java
+if [ "$JAVA_HOME" = "" ]; then
+ JAVA=java
+fi
+
+vers=$($JAVA -version 2>&1 | grep "version" | awk '{print $3}' | tr -d \")
+bit64=$($JAVA -version 2>&1 | grep "64-Bit")
+if [ "$bit64" != "" ]; then
+  vers="$vers (64bit)"
+fi
+echo "## using java $vers from $JAVA_HOME"
+
+function printBashUsage {
+  echo "$(basename $0): Start a Gpahhopper server."
+  echo "Default user access at 0.0.0.0:8989 and API access at 0.0.0.0:8989/route"
+  echo ""
+  echo "Usage"
+  echo "$(basename $0) [<parameter> ...] "
+  echo ""
+  echo "parameters:"
+  echo "-i | --input <osm-file>   OSM local input file location"
+  echo "--url <url>               download input file from a url and save as data.pbf"
+  echo "--import                  only create the graph cache, to be used later for faster starts"
+  echo "-c | --config <config>    application configuration file location"
+  echo "-o | --graph-cache <dir>  directory for graph cache output"
+  echo "-p | --profiles <string>  comma separated list of vehicle profiles"
+  echo "--port <port>             port for web server [default: 8989]"
+  echo "--host <host>             host address of the web server [default: 0.0.0.0]"
+  echo "-h | --help               display this message"
+}
+
+# one character parameters have one minus character'-'. longer parameters have two minus characters '--'
+while [ ! -z $1 ]; do
+  case $1 in
+    --import) ACTION=import; shift 1;;
+    -c|--config) CONFIG="$2"; shift 2;;
+    -i|--input) FILE="$2"; shift 2;;
+    --url) URL="$2"; shift 2;;
+    -o|--graph-cache) GRAPH="$2"; shift 2;;
+    -p|--profiles) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.graphhopper.graph.flag_encoders=$2"; shift 2;;
+    --port) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.application_connectors[0].port=$2"; shift 2;;
+    --host) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.application_connectors[0].bind_host=$2"; shift 2;;
+    -h|--help) printBashUsage
+        exit 0;;
+    -*) echo "Option unknown: $1"
+        echo
+        printBashUsage
+        exit 2;;
+  esac
+done
+
+# Defaults
+: "${ACTION:=server}"
+: "${GRAPH:=/data/default-gh}"
+: "${CONFIG:=config-alltrails.yml}"
+: "${JAVA_OPTS:=-Xmx1g -Xms1g}"
+: "${JAR:=$(find . -type f -name "*.jar")}"
+
+if [ "$URL" != "" ]; then
+  wget -S -nv -O "${FILE:=data.pbf}" "$URL"
+fi
+
+# create the directories if needed
+mkdir -p $(dirname "${GRAPH}")
+
+echo "## Executing $ACTION. JAVA_OPTS=$JAVA_OPTS"
+
+exec "$JAVA" $JAVA_OPTS ${FILE:+-Ddw.graphhopper.datareader.file="$FILE"} -Ddw.graphhopper.graph.location="$GRAPH" \
+        $GH_WEB_OPTS -jar "$JAR" $ACTION $CONFIG

--- a/alltrails/helm/graphhopper-service/.helmignore
+++ b/alltrails/helm/graphhopper-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/alltrails/helm/graphhopper-service/Chart.yaml
+++ b/alltrails/helm/graphhopper-service/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: graphhopper-service
+description: A Helm chart for GraphHopper Routing Service
+type: application
+version: 0.1.0

--- a/alltrails/helm/graphhopper-service/templates/NOTES.txt
+++ b/alltrails/helm/graphhopper-service/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "graphhopper-service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "graphhopper-service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "graphhopper-service.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "graphhopper-service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/alltrails/helm/graphhopper-service/templates/_helpers.tpl
+++ b/alltrails/helm/graphhopper-service/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "graphhopper-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+App version.
+*/}}
+{{- define "graphhopper-service.appVersion" -}}
+{{- default "1.0" .Values.image.tag }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "graphhopper-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "graphhopper-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "graphhopper-service.labels" -}}
+helm.sh/chart: {{ include "graphhopper-service.chart" . }}
+{{ include "graphhopper-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "graphhopper-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "graphhopper-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "graphhopper-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "graphhopper-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "graphhopper-service.fullname" . }}
+  labels:
+    {{- include "graphhopper-service.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "graphhopper-service.selectorLabels" . | nindent 6 }}
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        {{- include "graphhopper-service.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: graphhopper-service
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.awsAccount }}.dkr.ecr.{{ .Values.region }}.amazonaws.com/graphhopper-service:{{ include "graphhopper-service.appVersion" . }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        envFrom:
+          - secretRef:
+              name: graphhopper-service-secrets
+          - configMapRef:
+              name: graphhopper-infrastructure
+        env:
+          - name: ENABLE_S3_CACHE
+            value: "true"
+          - name: AWS_REGION
+            value: us-west-2
+          - name: AWS_WEB_IDENTITY_TOKEN_FILE
+            value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+          - name: PRODUCTION
+            value: "true"
+          - name: CREATE_DEFAULT_S3_BUCKETS
+            value: "true"
+        lifecycle: 
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c" , "sleep 30"]
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          failureThreshold: 5
+          periodSeconds: 2
+          initialDelaySeconds: 30
+        volumeMounts:
+        - mountPath: /graphhopper/data
+          name: s3-filesystem
+      volumes:
+      - name: s3-filesystem
+        persistentVolumeClaim:
+          claimName: graphhopper-service              
+

--- a/alltrails/helm/graphhopper-service/templates/hpa.yaml
+++ b/alltrails/helm/graphhopper-service/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "graphhopper-service.fullname" . }}
+  labels:
+    {{- include "graphhopper-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "graphhopper-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/alltrails/helm/graphhopper-service/templates/service.yaml
+++ b/alltrails/helm/graphhopper-service/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "graphhopper-service.fullname" . }}
+  labels: {{- include "graphhopper-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: http
+  selector:
+    {{- include "graphhopper-service.selectorLabels" . | nindent 4 }}

--- a/alltrails/helm/graphhopper-service/values-alpha.yaml
+++ b/alltrails/helm/graphhopper-service/values-alpha.yaml
@@ -1,0 +1,24 @@
+awsAccount: "873326996015"
+railsEnv: alpha
+
+resources:
+  limits:
+    memory: 2G
+  requests:
+    cpu: "0.5"
+    memory: 2G
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+additionalVolumes: {}
+
+externalSecret:
+  namespace: alpha
+  ssmKey: alpha/graphhopper-service/credentials
+
+datadog:
+  environment: alpha

--- a/alltrails/helm/graphhopper-service/values.yaml
+++ b/alltrails/helm/graphhopper-service/values.yaml
@@ -1,0 +1,44 @@
+replicaCount: 1
+
+image:
+  repository: 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service
+  pullPolicy: Always
+  tag: "graphhopper-service"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+    
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8989
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+additionalVolumeMounts: {}

--- a/alltrails/scripts/build_graphhopper.sh
+++ b/alltrails/scripts/build_graphhopper.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+BUILDKIT_PROGRESS=plain DOCKER_BUILDKIT=1 docker buildx build \
+  -t graphhopper-service --file alltrails/Dockerfile . 

--- a/alltrails/scripts/build_linux_graphhopper.sh
+++ b/alltrails/scripts/build_linux_graphhopper.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+echo "Building graphhopper-service:graphhopper-service-test"
+BUILDKIT_PROGRESS=plain DOCKER_BUILDKIT=1 docker buildx build \
+  -t "graphhopper-service:graphhopper-service-test" \
+  --platform linux/amd64 --file alltrails/Dockerfile . 
+
+echo "Tagging graphhopper-service:graphhopper-service-test"
+docker tag graphhopper-service:graphhopper-service-test 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service-test
+
+echo "Pushing graphhopper-service:graphhopper-service-test"
+docker push 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service-test

--- a/core/src/main/java/com/graphhopper/AtGlobals.java
+++ b/core/src/main/java/com/graphhopper/AtGlobals.java
@@ -23,12 +23,16 @@ public class AtGlobals {
               try {
                   // Long wayId = Long.valueOf(nextLine[0]);
                   Long wayId = Double.valueOf(nextLine[0]).longValue();
-                  Double popularity = Double.valueOf(nextLine[1]);
-                  Double scenic_value = Double.valueOf(nextLine[2]);
-                  if (popularity > 0.0)
-                    popularities.put(wayId, popularity);
-                  if (scenic_value > 0.0)
-                    scenicValues.put(wayId, scenic_value);
+                  if (!nextLine[1].isEmpty()) {
+                    Double popularity = Double.valueOf(nextLine[1]);
+                    if (popularity > 0.0)
+                      popularities.put(wayId, popularity);
+                  }
+                  if (!nextLine[2].isEmpty()) {
+                    Double scenic_value = Double.valueOf(nextLine[2]);
+                    if (scenic_value > 0.0)
+                      scenicValues.put(wayId, scenic_value);
+                  }
               } catch (Exception ex) {
                   System.out.println("CSV parse exception: " + ex.getMessage());
               }


### PR DESCRIPTION
Rather than having a separate repo for the scripts to build and deploy to AWS a Docker image for our infrastructure, add them to the `graphhopper fork` in the folder `alltrails`.

This is intended as an initial commit of these scripts into the repo, and they are tested for building local and EKS deployed services.

The `helm` charts need to be further reviewed, but we can leave this for a bit until we're come to a final design for the routing APIs and services in early Jan'25.