### PR TITLE
DISCO-13672: metrics endpoint

### DIFF
--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -1,19 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ad.datadoghq.com/graphhopper-service.checks: |
-      {
-        "openmetrics": {
-          "instances": [
-            {
-              "openmetrics_endpoint": "http://%%host%%:8989/metrics",
-              "namespace": "graphhopper-service",
-              "metrics": [".*"]
-            }
-          ]
-        }
-      }
   name: {{ include "graphhopper-service.fullname" . }}
   labels:
     {{- include "graphhopper-service.labels" . | nindent 4 }}
@@ -27,6 +14,19 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/graphhopper-service.checks: |
+          {
+            "openmetrics": {
+              "instances": [
+                {
+                  "openmetrics_endpoint": "http://%%host%%:8989/metrics",
+                  "namespace": "graphhopper-service",
+                  "metrics": [".*"]
+                }
+              ]
+            }
+          }
       labels:
         {{- include "graphhopper-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
         "openmetrics": {
           "instances": [
             {
-              "openmetrics_endpoint": "http://%%host%%:8989/metrics"
+              "openmetrics_endpoint": "http://%%host%%:8989/metrics",
+              "namespace": "graphhopper-service",
+              "metrics": [".*"]
             }
           ]
         }

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
                   "metrics": [
                     "jvm_*",
                     "process_*"
-                    "system__*"
+                    "system_*"
                   ]
                 }
               ]

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -1,6 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    ad.datadoghq.com/graphhopper-service.checks: |
+      {
+        "openmetrics": {
+          "instances": [
+            {
+              "openmetrics_endpoint": "http://%%host%%:8989/metrics"
+            }
+          ]
+        }
+      }
   name: {{ include "graphhopper-service.fullname" . }}
   labels:
     {{- include "graphhopper-service.labels" . | nindent 4 }}
@@ -14,17 +25,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        ad.datadoghq.com/graphhopper-service.checks: |
-          {
-            "openmetrics": {
-              "instances": [
-                {
-                  "openmetrics_endpoint": "http://%%host%%:8989/metrics"
-                }
-              ]
-            }
-          }
       labels:
         {{- include "graphhopper-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -20,12 +20,7 @@ spec:
             "openmetrics": {
               "instances": [
                 {
-                  "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
-                  "metrics": [
-                    "jvm_*",
-                    "process_*"
-                    "system_*"
-                  ]
+                  "openmetrics_endpoint": "http://%%host%%:8989/metrics"
                 }
               ]
             }

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheusMetrics: |
+        ad.datadoghq.com/graphhopper-service.checks: |
           {
             "openmetrics": {
               "instances": [

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -12,6 +12,22 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheusMetrics: |
+          {
+            "openmetrics": {
+              "instances": [
+                {
+                  "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
+                  "metrics": [
+                    "jvm_*",
+                    "process_*"
+                    "system__*"
+                  ]
+                }
+              ]
+            }
+          }
       labels:
         {{- include "graphhopper-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/alltrails/helm/graphhopper-service/values.yaml
+++ b/alltrails/helm/graphhopper-service/values.yaml
@@ -42,3 +42,8 @@ tolerations: []
 affinity: {}
 
 additionalVolumeMounts: {}
+
+datadog:
+  prometheusScrape:
+    enabled: true
+    serviceEndpoints: true

--- a/alltrails/scripts/build_linux_graphhopper.sh
+++ b/alltrails/scripts/build_linux_graphhopper.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-echo "Building graphhopper-service:graphhopper-service-test"
+echo "Building graphhopper-service:graphhopper-service"
 BUILDKIT_PROGRESS=plain DOCKER_BUILDKIT=1 docker buildx build \
-  -t "graphhopper-service:graphhopper-service-test" \
+  -t "graphhopper-service:graphhopper-service" \
   --platform linux/amd64 --file alltrails/Dockerfile . 
 
-echo "Tagging graphhopper-service:graphhopper-service-test"
-docker tag graphhopper-service:graphhopper-service-test 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service-test
+echo "Tagging graphhopper-service:graphhopper-service"
+docker tag graphhopper-service:graphhopper-service 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service
 
-echo "Pushing graphhopper-service:graphhopper-service-test"
-docker push 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service-test
+echo "Pushing graphhopper-service:graphhopper-service"
+docker push 873326996015.dkr.ecr.us-west-2.amazonaws.com/graphhopper-service:graphhopper-service

--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -125,6 +125,19 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-bom</artifactId>
+            <version>1.14.4</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.14.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -307,5 +307,6 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
         environment.healthChecks().register("graphhopper", new GraphHopperHealthCheck(graphHopper));
         environment.jersey().register(environment.healthChecks());
         environment.jersey().register(HealthCheckResource.class);
+        environment.jersey().register(new MetricsResource());
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/resources/MetricsResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/MetricsResource.java
@@ -1,0 +1,33 @@
+package com.graphhopper.resources;
+
+import io.micrometer.core.instrument.binder.jvm.*;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("metrics")
+public class MetricsResource {
+
+    private static final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
+    public MetricsResource() {
+        setupMetrics();
+    }
+
+    @GET
+    public String getMetrics() {
+        return registry.scrape();
+    }
+
+    private static void setupMetrics() {
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new JvmThreadDeadlockMetrics().bindTo(registry);
+    }
+}


### PR DESCRIPTION
Adds [micrometer](https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html) to the project to collect JVM metrics and output them in prometheus format.

Adds configuration to `values.yaml` to tell datadog to poll this endpoint

I added all the JVM metrics outlined [here](https://docs.micrometer.io/micrometer/reference/reference/jvm.html)