### PR TITLE
DISCO-12985: Add at_gain_percent

### DIFF
--- a/alltrails/config/config-alltrails.yml
+++ b/alltrails/config/config-alltrails.yml
@@ -93,7 +93,7 @@ graphhopper:
   graph.encoded_values: foot_road_access, bike_priority, bike_road_access, country, road_class, roundabout, car_access, road_access,
     car_average_speed, mtb_rating, mtb_priority, mtb_access, mtb_average_speed, racingbike_priority, racingbike_access, racingbike_average_speed,
     foot_access, hike_rating, foot_priority, foot_network, foot_average_speed, average_slope,
-    surface, smoothness, track_type, at_popularity, at_scenic_value
+    surface, smoothness, track_type, at_popularity, at_scenic_value, at_gain_percent
 
   #### Speed, hybrid and flexible mode ####
 

--- a/core/src/main/java/com/graphhopper/routing/ev/AtGainPercent.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/AtGainPercent.java
@@ -1,0 +1,10 @@
+package com.graphhopper.routing.ev;
+
+public class AtGainPercent {
+    public static final String KEY = "at_gain_percent";
+
+    public static DecimalEncodedValue create() {
+        // We're passing storeTwoDirections = true, so can store gain in each direction
+        return new DecimalEncodedValueImpl(KEY, 5, 0, 1, false, true, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -228,11 +228,14 @@ public class DefaultImportRegistry implements ImportRegistry {
             return ImportUnit.create(name, props -> AverageSlope.create(), null, "slope_calculator");
         else if (MaxSlope.KEY.equals(name))
             return ImportUnit.create(name, props -> MaxSlope.create(), null, "slope_calculator");
+        else if (AtGainPercent.KEY.equals(name))
+            return ImportUnit.create(name, props -> AtGainPercent.create(), null, "slope_calculator");
         else if ("slope_calculator".equals(name))
             return ImportUnit.create(name, null,
                     (lookup, props) -> new SlopeCalculator(
                             lookup.hasEncodedValue(MaxSlope.KEY) ? lookup.getDecimalEncodedValue(MaxSlope.KEY) : null,
-                            lookup.hasEncodedValue(AverageSlope.KEY) ? lookup.getDecimalEncodedValue(AverageSlope.KEY) : null
+                            lookup.hasEncodedValue(AverageSlope.KEY) ? lookup.getDecimalEncodedValue(AverageSlope.KEY) : null,
+                            lookup.hasEncodedValue(AtGainPercent.KEY) ? lookup.getDecimalEncodedValue(AtGainPercent.KEY) : null
                     ));
         else if (BikeNetwork.KEY.equals(name) || MtbNetwork.KEY.equals(name) || FootNetwork.KEY.equals(name))
             return ImportUnit.create(name, props -> RouteNetwork.create(name), null);

--- a/core/src/test/java/com/graphhopper/routing/util/SlopeCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/SlopeCalculatorTest.java
@@ -15,7 +15,7 @@ class SlopeCalculatorTest {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
         new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc, null);
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
         ReaderWay way = new ReaderWay(1L);
@@ -40,7 +40,7 @@ class SlopeCalculatorTest {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
         new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc, null);
         ArrayEdgeIntAccess intAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
         ReaderWay way = new ReaderWay(1L);
@@ -70,7 +70,7 @@ class SlopeCalculatorTest {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
         new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc, null);
         int edgeId = 0;
         creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
         assertEquals(31, maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
@@ -91,7 +91,7 @@ class SlopeCalculatorTest {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
         new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc, null);
 
         int edgeId = 0;
         creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
@@ -111,7 +111,7 @@ class SlopeCalculatorTest {
         DecimalEncodedValue maxEnc = MaxSlope.create();
         new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
 
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc, null);
         creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
         assertEquals(0, maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
         assertEquals(0, averageEnc.getDecimal(false, edgeId, intAccess), 1e-3);


### PR DESCRIPTION
Adds `at_gain_percent` so that a "least elevation gain" costing option can be implemented.  Trying to use the existing attributes `average_slope` or `max_slope` did not yield good results.  See Jira for suggested custom model to leverage new attribute.

Gain is calculated for each segment with a small smoothing effect of requiring that the elevation moves up or down by 3m in order for a new gain/loss value to be logged.  Smoothing-out fluctuations is not ultra-crucial here because we're only comparing gains rather than using absolutely values, but did yield more consistent results.

Gain is stored for both directions for the segment: the loss calculated for the segment moving forwards becomes the gain for the segment when moving backwards.

Gain is stored as a percentage of the segment distance, so it is comparable to the existing `average_slope` attribute, indeed the average slope of a segment should equal "gain minus loss" (ie "forward gain minus reverse gain") within rounding errors.