### PR TITLE
CHORE: Add Datadog instrumentation

### DIFF
--- a/alltrails/Dockerfile
+++ b/alltrails/Dockerfile
@@ -6,6 +6,11 @@ COPY . .
 
 RUN mvn clean install -DskipTests
 
+FROM alpine/curl@sha256:df202600793f003a0a8dda18287d868802984a976f103cf59165d5aafa4e0007 AS fetch-dd
+
+WORKDIR /dd
+
+RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/java-tracer-v1'
 
 FROM eclipse-temurin:21.0.1_12-jre
 
@@ -19,10 +24,12 @@ COPY alltrails/config/graphhopper.sh ./
 
 COPY alltrails/config/config-alltrails.yml alltrails/config/atv.json ./alltrails/config
 
+COPY --from=fetch-dd /dd/dd-java-agent.jar /usr/lib/dd-java-agent.jar
+
 EXPOSE 8989 8990
 
 HEALTHCHECK --interval=5s --timeout=3s CMD curl --fail http://localhost:8989/health || exit 1
 
-ENV JAVA_OPTS "-Xmx156g -Xms156g"
+ENV JAVA_OPTS "-Xmx156g -Xms156g -javaagent:/usr/lib/dd-java-agent.jar"
 
 ENTRYPOINT [ "./graphhopper.sh", "-c", "alltrails/config/config-alltrails.yml", "-o", "/graphhopper/data/default-gh" ]

--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "graphhopper-service.fullname" . }}
   labels:
     {{- include "graphhopper-service.labels" . | nindent 4 }}
+    tags.datadoghq.com/service: "graphhopper"
+    tags.datadoghq.com/version: "1.0"
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -29,6 +31,10 @@ spec:
           }
       labels:
         {{- include "graphhopper-service.selectorLabels" . | nindent 8 }}
+        tags.datadoghq.com/service: "graphhopper"
+        tags.datadoghq.com/version: "1.0"
+        tags.datadoghq.com/env: {{ .Values.datadog.environment }}
+        admission.datadoghq.com/enabled: "true"
     spec:
       topologySpreadConstraints:
         - maxSkew: 2
@@ -74,6 +80,26 @@ spec:
         volumeMounts:
         - mountPath: /graphhopper/data
           name: s3-filesystem
+        env:
+        - name: DD_ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/env']
+        - name: DD_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tags.datadoghq.com/service']
+        - name: DD_VERSION
+          value: {{ include "graphhopper-service.appVersion" . }}
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: DD_LOGS_INJECTION
+          value: "true"
+        - name: DD_TRACE_SAMPLE_RATE
+          value: "1"
+
       volumes:
       - name: s3-filesystem
         persistentVolumeClaim:


### PR DESCRIPTION
The Change
===

Adds basic datadog instrumentation to the graphhopper service.

This change follows the [datadog docs]: add an agent jar and some
`JAVA_OPTS` flags to autoinstrument a java configuration.

Testing
===

To test I first built and pushed a new container image with the
datadog agent under the `dd-trace-test` tag. Then, I created my
own custom `values-danny.yaml` configuration and then installed a
test helm release to alpha us-west-2:

```bash
helm upgrade graphhopper-dd-test alltrails/helm/graphhopper-service -i --values "./alltrails/helm/graphhopper-service/values-alpha.yaml" --values alltrails/helm/graphhopper-service/values-danny.yaml --set "region=us-west-2"
```

Once the pods came up I `kubectl exec`'d into a monolith pod
and used `curl` to verify that routes worked and to generate traces:

```bash
curl 'http://graphhopper-dd-test-graphhopper-service:8989/route?point=40.3517,-106.3860&point=40.2831,-106.3466&profile=hike'
```

You can see an example trace from the routing endpoint
[here][route trace].

Obviously we need to do some more fine-tuning on which traces
we exclude, but I feel this is a good starting point.

NB: Since this test release was deployed with a completely separate
kubernetes service and since the selector labels on the pods
didn't match the selector used by the k8s service for the _real_
deployment, this test release was never available outside of our
cluster while I tested.

[datadog docs]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/java/?tab=jetty
[route trace]: https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20service%3Agraphhopper&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=8022016742016526600&spanType=service-entry&storage=hot&timeHint=1742876724508&trace=67e23034000000002e2fe4444b0001478022016742016526600&traceID=67e23034000000002e2fe4444b000147&view=spans&start=1742876102805&end=1742877002805&paused=false