### PR TITLE
CHORE: spread pods between spot and on-demand

### DIFF
--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -37,9 +37,16 @@ spec:
         admission.datadoghq.com/enabled: "true"
     spec:
       topologySpreadConstraints:
-        - maxSkew: 2
-          minDomains: 4
+        - maxSkew: 1
+          minDomains: 2
           topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              name: graphhopper-service
+        - maxSkew: 5
+          minDomains: 2
+          topologyKey: karpenter.sh/capacity-type
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
@@ -52,12 +59,22 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: karpenter.sh/nodepool
-                    operator: In
-                    values: ["xlarge"]
-                  - key: karpenter.sh/capacity-type
-                    operator: NotIn
-                    values: [ "spot" ]
+                - key: karpenter.sh/nodepool
+                  operator: In
+                  values: [ "xlarge" ]
+          preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 20
+                preference:
+                  matchExpressions:
+                    - key: karpenter.sh/capacity-type
+                      operator: In
+                      values: [ "on-demand" ]
+              - weight: 80
+                preference:
+                  matchExpressions:
+                    - key: karpenter.sh/capacity-type
+                      operator: In
+                      values: [ "spot" ]
       serviceAccountName: graphhopper-service
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/alltrails/helm/graphhopper-service/values-alpha.yaml
+++ b/alltrails/helm/graphhopper-service/values-alpha.yaml
@@ -1,4 +1,8 @@
 awsAccount: "873326996015"
 
+autoscaling:
+  minReplicas: 2
+  maxReplicas: 10
+
 datadog:
   environment: alpha

--- a/alltrails/helm/graphhopper-service/values-production.yaml
+++ b/alltrails/helm/graphhopper-service/values-production.yaml
@@ -1,4 +1,8 @@
 awsAccount: "434355312983"
 
+autoscaling:
+  minReplicas: 4
+  maxReplicas: 10
+
 datadog:
   environment: production

--- a/alltrails/helm/graphhopper-service/values.yaml
+++ b/alltrails/helm/graphhopper-service/values.yaml
@@ -6,8 +6,6 @@ replicaCount: 1
 
 autoscaling:
   enabled: true
-  minReplicas: 4
-  maxReplicas: 10
   targetCPUUtilizationPercentage: 80
 
 resources:


### PR DESCRIPTION
* Ensure that we have at least one `on-demand` instance.
* Use `spot` instances to scale.

This is a summary of the current node affinity / topology spread constraints. Not all of these changes were made in this PR, but to understand the whole deployment, it's helpful to see them together.

Ensure that we do not add all of our `spot` instances to the same node:
```
topologySpreadConstraints:
  - maxSkew: 1
     minDomains: 2
      topologyKey: kubernetes.io/hostname
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
        name: graphhopper-service
```

Ensure that we have at least 1 on demand instance (and 2 if there are 7 total pods):
```
topologySpreadConstraints:
  - maxSkew: 5
     minDomains: 2
      topologyKey: karpenter.sh/capacity-type
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
        name: graphhopper-service
```

Allow scheduling on `xlarge` nodepool:
```
tolerations:
  - key: "xlarge-only"
     value: "true"
```

Require `xlarge` nodepool:
```
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
          - key: karpenter.sh/nodepool
             operator: In
             values: [ "xlarge" ]
```

Weighted preferences for spot and on-demand:
```
affinity:
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 20
          preference:
             matchExpressions:
               - key: karpenter.sh/capacity-type
                  operator: In
                  values: [ "on-demand" ]
       - weight: 80
          preference:
             matchExpressions:
               - key: karpenter.sh/capacity-type
                  operator: In
                  values: [ "spot" ]
```
