### PR TITLE
DISCO-15859: Allow routing on private trails

### DIFF
--- a/alltrails/helm/graphhopper-service-importer/README.md
+++ b/alltrails/helm/graphhopper-service-importer/README.md
@@ -98,7 +98,7 @@ kubectl delete job graphhopper-service-importer
 Inspect the current default files:
 ```bash
 latest_data_version=$(head -n 1 ./dataversion)
-aws s3 ls s3://alltrails-alpha-us-west-2-graphhopper-service/$latest_data_version$> --recursive
+aws s3 ls s3://alltrails-alpha-us-west-2-graphhopper-service/$latest_data_version --recursive
 ```
 
 And compare these to the new files:
@@ -128,9 +128,10 @@ echo "default-gh-$timestamp" > ./dataversion
 Create a pull request for this change and merge to master.
 This is necessary because the new image will be tagged with the git hash.
 
-On the updated master branch, build a new image to read from the new directory
+On the updated master branch, build and push a new image to read from the new directory
 ```bash
 make docker-build ENV=alpha
+make docker-push ENV=alpha
 ```
 
 ## Update Alpha Deployment

--- a/core/src/main/resources/com/graphhopper/custom_models/hike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/hike.json
@@ -7,9 +7,8 @@
 
 {
   "priority": [
-    { "if": "!foot_access || hike_rating >= 5", "multiply_by": "0"},
+    { "if": "hike_rating >= 5", "multiply_by": "0"},
     { "else": "", "multiply_by": "foot_priority"},
-    { "if": "foot_road_access == PRIVATE", "multiply_by": "0" },
     { "if": "foot_network == INTERNATIONAL || foot_network == NATIONAL", "multiply_by": "1.7"},
     { "else_if": "foot_network == REGIONAL || foot_network == LOCAL", "multiply_by": "1.5"}
   ],

--- a/dataversion
+++ b/dataversion
@@ -1,1 +1,1 @@
-default-gh-1744919675
+default-gh-1746469916


### PR DESCRIPTION
This ended up being a small change, but after merging this we **must:**
- rebuild Java executable (which will occur anyway as part of the Docker image rebuild)
- reimport OSM to rebuild routing network files using the **new** image
- deploy the new image and the new routing network files at the same time (the latter can be done slightly before the former if necessary, since running images do not re-import their files after startup)
