### PR TITLE
CHORE: update deployment timeouts

### DIFF
--- a/alltrails/helm/graphhopper-service/templates/deployment.yaml
+++ b/alltrails/helm/graphhopper-service/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           httpGet:
             path: /health
             port: 8989
-          failureThreshold: 60
+          failureThreshold: 90
           periodSeconds: 10
           initialDelaySeconds: 120
         livenessProbe:

--- a/alltrails/scripts/deploy.sh
+++ b/alltrails/scripts/deploy.sh
@@ -12,7 +12,7 @@ helm upgrade --install "${DEPLOYMENT_NAME}" \
 alltrails/helm/graphhopper-service \
     --kube-context "${KUBE_CONTEXT}" \
     --namespace "${NAMESPACE}" \
-    --wait --timeout 10m --atomic --debug \
+    --wait --timeout 16m --atomic --debug \
     --values "${VALUES}" \
     --set image.tag="${IMAGE_TAG}" \
     --set region="${REGION}"


### PR DESCRIPTION
This is needed for the regional deployments. There must be some additional latency when getting the graph from s3.