### PR TITLE
DISCO-16457: Fix Settings link crash

### DIFF
--- a/web-bundle/src/main/resources/com/graphhopper/maps/config.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/config.js
@@ -25,4 +25,5 @@ const config = {
         ],
         snapPreventions: ['ferry'],
     },
+    profile_group_mapping: {},
 }


### PR DESCRIPTION
Followup for recent DISCO-16457 merge where the (unimportant) Settings link crashes